### PR TITLE
clab stdout and stderr and clab destroy support

### DIFF
--- a/builder/clab.go
+++ b/builder/clab.go
@@ -1,11 +1,13 @@
 package builder
 
 import (
+	"bytes"
 	"fmt"
-	"github.com/Lachstec/digsinet-ng/types"
-	"gopkg.in/yaml.v3"
 	"log"
 	"os/exec"
+
+	"github.com/Lachstec/digsinet-ng/types"
+	"gopkg.in/yaml.v3"
 )
 
 type ClabBuilder struct {
@@ -27,6 +29,14 @@ func (b *ClabBuilder) DeployTopology(topology types.Topology) error {
 		return fmt.Errorf("failed to get stdin pipe: %w", err)
 	}
 
+	// Store stdout of the process
+	stdout := bytes.NewBuffer([]byte{})
+	proc.Stdout = stdout
+
+	// Store stderr of the process
+	stderr := bytes.NewBuffer([]byte{})
+	proc.Stderr = stderr
+
 	// Start the process
 	if err = proc.Start(); err != nil {
 		return fmt.Errorf("failed to start process: %w", err)
@@ -54,7 +64,7 @@ func (b *ClabBuilder) DeployTopology(topology types.Topology) error {
 
 	// Wait for the process to complete
 	if err = proc.Wait(); err != nil {
-		return fmt.Errorf("process finished with error: %w", err)
+		return fmt.Errorf("process finished with error: %w stdout: %s stderr: %s", err, stdout, stderr)
 	}
 
 	log.Print("Topology deployment completed successfully.")
@@ -73,6 +83,14 @@ func (b *ClabBuilder) DestroyTopology(topology types.Topology) error {
 		return fmt.Errorf("failed to get stdin pipe: %w", err)
 	}
 
+	// Store stdout of the process
+	stdout := bytes.NewBuffer([]byte{})
+	proc.Stdout = stdout
+
+	// Store stderr of the process
+	stderr := bytes.NewBuffer([]byte{})
+	proc.Stderr = stderr
+
 	// Start the process
 	if err = proc.Start(); err != nil {
 		return fmt.Errorf("failed to start process: %w", err)
@@ -100,9 +118,10 @@ func (b *ClabBuilder) DestroyTopology(topology types.Topology) error {
 
 	// Wait for the process to complete
 	if err = proc.Wait(); err != nil {
-		return fmt.Errorf("process finished with error: %w", err)
+		return fmt.Errorf("process finished with error: %w stdout: %s stderr: %s", err, stdout,
+			stderr)
 	}
 
-	log.Print("Topology deployment completed successfully.")
+	log.Print("Topology successfully destroyed.")
 	return nil
 }

--- a/cmd/clab_destroyer.go
+++ b/cmd/clab_destroyer.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"github.com/Lachstec/digsinet-ng/builder"
+	"github.com/Lachstec/digsinet-ng/types"
+)
+
+func main() {
+	b := types.NewTopologyBuilder()
+	b.Name("srlceos01")
+	b.AddNode("nokia_srlinux", "nokia_srlinux")
+	b.AddNode("arista_ceos", "ceos")
+	b.AddLink("nokia_srlinux", "arista_ceos", "e1-1", "eth1")
+
+	topo := b.Build()
+
+	clab := builder.NewClabBuilder()
+	err := clab.DestroyTopology(topo)
+	if err != nil {
+		panic(err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,11 @@ go 1.23
 require (
 	github.com/go-yaml/yaml v2.1.0+incompatible
 	github.com/stretchr/testify v1.10.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )


### PR DESCRIPTION
* added stdout and stderr output to deployment of clab topology
* added a destroy cmd for clab topo cleanup