### PR TITLE
Logging durch ZeroLog

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -13,4 +13,6 @@ type Builder interface {
 	// DestroyTopology destroy the specified Topology, leaving no data remaining.
 	// Returns an error if the given types.Topology is not valid or if something goes wrong while destruction.
 	DestroyTopology(types.Topology) error
+	// Id returns the Id of the Builder as a string.
+	Id() string
 }

--- a/builder/clab.go
+++ b/builder/clab.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"fmt"
 	"github.com/Lachstec/digsinet-ng/types"
+	"github.com/rs/zerolog/log"
 	"gopkg.in/yaml.v3"
-	"log"
 	"os/exec"
 )
 
@@ -17,7 +17,10 @@ func NewClabBuilder() *ClabBuilder {
 }
 
 func (b *ClabBuilder) DeployTopology(topology types.Topology) error {
-	log.Print("Deploying Topology with Containerlab Builder...")
+
+	log.Info().
+		Str("Builder", b.Id()).
+		Msg("Deploying Topology...")
 
 	// Prepare the command
 	proc := exec.Command("clab", "deploy", "--topo", "-")
@@ -25,6 +28,9 @@ func (b *ClabBuilder) DeployTopology(topology types.Topology) error {
 	// Connect stdin for the process
 	stdin, err := proc.StdinPipe()
 	if err != nil {
+		log.Error().
+			Str("Builder", b.Id()).
+			Msg("Failed to create stdin pipe")
 		return fmt.Errorf("failed to get stdin pipe: %w", err)
 	}
 
@@ -38,35 +44,53 @@ func (b *ClabBuilder) DeployTopology(topology types.Topology) error {
 
 	// Start the process
 	if err = proc.Start(); err != nil {
+		log.Error().
+			Str("Builder", b.Id()).
+			Msg("Failed to create stdin pipe")
 		return fmt.Errorf("failed to start process: %w", err)
 	}
 
 	// Serialize the topology spec
 	topologySpec, err := yaml.Marshal(topology)
 	if err != nil {
+		log.Error().
+			Str("Builder", b.Id()).
+			Msg("Failed to marshal topology spec")
 		return fmt.Errorf("failed to marshal topology: %w", err)
 	}
 
-	// Debug: print the topology spec to ensure correctness
-	log.Printf("Topology spec to be sent: %s", string(topologySpec))
+	log.Debug().
+		Str("Builder", b.Id()).
+		Msg("Topology Spec to be sent: ")
 
 	// Write the topology spec to stdin
 	_, err = stdin.Write(topologySpec)
 	if err != nil {
+		log.Error().
+			Str("Builder", b.Id()).
+			Msg("Failed to write topology spec to stdin")
 		return fmt.Errorf("failed to write to stdin: %w", err)
 	}
 
 	// Close stdin to signal the end of input
 	if err := stdin.Close(); err != nil {
+		log.Error().
+			Str("Builder", b.Id()).
+			Msg("Failed to close stdin")
 		return fmt.Errorf("failed to close stdin: %w", err)
 	}
 
 	// Wait for the process to complete
 	if err = proc.Wait(); err != nil {
+		log.Error().
+			Str("Builder", b.Id()).
+			Msg("Failed to deploy topology")
 		return fmt.Errorf("process finished with error: %w stdout: %s stderr: %s", err, stdout, stderr)
 	}
 
-	log.Print("Topology deployment completed successfully.")
+	log.Info().
+		Str("Builder", b.Id()).
+		Msg("Successfully deployed topology")
 
 	// Start interfaces of the nodes
 	//log.Print("Starting interfaces of the nodes...")
@@ -86,7 +110,9 @@ func (b *ClabBuilder) DeployTopology(topology types.Topology) error {
 }
 
 func (b *ClabBuilder) DestroyTopology(topology types.Topology) error {
-	log.Print("Destroying Topology with Containerlab Builder...")
+	log.Info().
+		Str("Builder", b.Id()).
+		Msg("Destroying Topology...")
 
 	// Prepare the command
 	proc := exec.Command("clab", "destroy", "--topo", "-")
@@ -94,6 +120,9 @@ func (b *ClabBuilder) DestroyTopology(topology types.Topology) error {
 	// Connect stdin for the process
 	stdin, err := proc.StdinPipe()
 	if err != nil {
+		log.Error().
+			Str("Builder", b.Id()).
+			Msg("Failed to create stdin pipe")
 		return fmt.Errorf("failed to get stdin pipe: %w", err)
 	}
 
@@ -107,34 +136,57 @@ func (b *ClabBuilder) DestroyTopology(topology types.Topology) error {
 
 	// Start the process
 	if err = proc.Start(); err != nil {
+		log.Error().
+			Str("Builder", b.Id()).
+			Msg("Failed to start process")
 		return fmt.Errorf("failed to start process: %w", err)
 	}
 
 	// Serialize the topology spec
 	topologySpec, err := yaml.Marshal(topology)
 	if err != nil {
+		log.Error().
+			Str("Builder", b.Id()).
+			Msg("Failed to marshal topology spec")
 		return fmt.Errorf("failed to marshal topology: %w", err)
 	}
 
 	// Debug: print the topology spec to ensure correctness
-	log.Printf("Topology spec to be sent: %s", string(topologySpec))
+	log.Debug().
+		Str("Builder", b.Id()).
+		Msg("Topology Spec to be sent: ")
 
 	// Write the topology spec to stdin
 	_, err = stdin.Write(topologySpec)
 	if err != nil {
+		log.Error().
+			Str("Builder", b.Id()).
+			Msg("Failed to write topology spec to stdin")
 		return fmt.Errorf("failed to write to stdin: %w", err)
 	}
 
 	// Close stdin to signal the end of input
 	if err := stdin.Close(); err != nil {
+		log.Error().
+			Str("Builder", b.Id()).
+			Msg("Failed to close stdin")
 		return fmt.Errorf("failed to close stdin: %w", err)
 	}
 
 	// Wait for the process to complete
 	if err = proc.Wait(); err != nil {
+		log.Error().
+			Str("Builder", b.Id()).
+			Msg("Failed to deploy topology")
 		return fmt.Errorf("process finished with error: %w stdout: %s stderr: %s", err, stdout, stderr)
 	}
 
-	log.Print("Topology successfully destroyed.")
+	log.Info().
+		Str("Builder", b.Id()).
+		Msg("Successfully deployed topology")
 	return nil
+}
+
+func (b *ClabBuilder) Id() string {
+	return "Containerlab"
 }

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -5,6 +5,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"github.com/Lachstec/digsinet-ng/log"
 	"os"
 
 	"github.com/Lachstec/digsinet-ng/config"
@@ -12,6 +13,8 @@ import (
 )
 
 func main() {
+	log.InitLogging()
+
 	environment := flag.String("e", "development", "")
 	flag.Usage = func() {
 		fmt.Println("Usage: server -e {mode}")

--- a/config/config.go
+++ b/config/config.go
@@ -3,8 +3,8 @@ package config
 // adapted from https://github.com/vsouza/go-gin-boilerplate
 
 import (
+	"github.com/rs/zerolog/log"
 	"github.com/spf13/viper"
-	"log"
 )
 
 var config *viper.Viper
@@ -19,7 +19,9 @@ func Init(env string) {
 	config.AddConfigPath("config/")
 	err = config.ReadInConfig()
 	if err != nil {
-		log.Fatal("error on parsing default configuration file")
+		log.Fatal().
+			Err(err).
+			Msg("Failed to read config")
 	}
 
 	envConfig := viper.New()
@@ -28,12 +30,16 @@ func Init(env string) {
 	envConfig.SetConfigName(env)
 	err = envConfig.ReadInConfig()
 	if err != nil {
-		log.Fatal("error on parsing env configuration file")
+		log.Fatal().
+			Err(err).
+			Msg("Failed to parse env configuration file")
 	}
 
 	err = config.MergeConfigMap(envConfig.AllSettings())
 	if err != nil {
-		log.Fatal("error on merging configuration files")
+		log.Fatal().
+			Err(err).
+			Msg("Failed to merge config")
 		return
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -28,12 +28,14 @@ require (
 	github.com/klauspost/cpuid/v2 v2.2.7 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
+	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.2 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
+	github.com/rs/zerolog v1.33.0 // indirect
 	github.com/sagikazarmark/locafero v0.4.0 // indirect
 	github.com/sagikazarmark/slog-shim v0.1.0 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
@@ -49,7 +51,7 @@ require (
 	golang.org/x/crypto v0.23.0 // indirect
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9 // indirect
 	golang.org/x/net v0.25.0 // indirect
-	golang.org/x/sys v0.20.0 // indirect
+	golang.org/x/sys v0.29.0 // indirect
 	golang.org/x/text v0.15.0 // indirect
 	google.golang.org/protobuf v1.34.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.23
 require (
 	github.com/gin-gonic/gin v1.10.0
 	github.com/go-yaml/yaml v2.1.0+incompatible
+	github.com/rs/zerolog v1.33.0
 	github.com/spf13/viper v1.19.0
 	github.com/stretchr/testify v1.10.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -35,7 +36,6 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.2 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/rs/zerolog v1.33.0 // indirect
 	github.com/sagikazarmark/locafero v0.4.0 // indirect
 	github.com/sagikazarmark/slog-shim v0.1.0 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect

--- a/log/logging.go
+++ b/log/logging.go
@@ -1,0 +1,13 @@
+package log
+
+import (
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"os"
+)
+
+// InitLogging initializes the default logger to use a zerolog
+// instance that logs to stdout by default.
+func InitLogging() {
+	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stdout})
+}

--- a/server/controllers/sibling.go
+++ b/server/controllers/sibling.go
@@ -4,7 +4,8 @@ import (
 	"github.com/Lachstec/digsinet-ng/builder"
 	"github.com/Lachstec/digsinet-ng/types"
 	"github.com/gin-gonic/gin"
-	"log"
+	"github.com/rs/zerolog/log"
+
 	"net/http"
 )
 
@@ -27,7 +28,9 @@ func (s SiblingController) GetSiblings(c *gin.Context) {
 func (s SiblingController) CreateSibling(c *gin.Context) {
 	var newSibling sibling
 	if err := c.BindJSON(&newSibling); err != nil {
-		log.Print("Failed to bind JSON: ", err)
+		log.Error().
+			Err(err).
+			Msg("Failed to bind JSON")
 		return
 	}
 
@@ -58,11 +61,15 @@ func (s SiblingController) StartSiblingByID(c *gin.Context) {
 				clab := builder.ClabBuilder{}
 				err := clab.DeployTopology(s.Topology)
 				if err != nil {
-					log.Printf("Failed to deploy topology: %s", err)
+					log.Error().
+						Err(err).
+						Msg("Failed to deploy topology")
 				}
 				return
 			default:
-				log.Printf("Unknown builder: %s", s.Builder)
+				log.Error().
+					Str("builder", s.Builder).
+					Msg("Unknown Builder: ")
 				return
 			}
 		}
@@ -79,11 +86,15 @@ func (s SiblingController) StopSiblingByID(c *gin.Context) {
 				clab := builder.ClabBuilder{}
 				err := clab.DestroyTopology(s.Topology)
 				if err != nil {
-					log.Printf("Failed to destroy topology: %s", err)
+					log.Error().
+						Err(err).
+						Msg("Failed to destroy topology")
 				}
 				return
 			default:
-				log.Printf("Unknown builder: %s", s.Builder)
+				log.Error().
+					Str("builder", s.Builder).
+					Msg("Unknown Builder: ")
 			}
 		}
 	}

--- a/server/rest_middlewares/auth.go
+++ b/server/rest_middlewares/auth.go
@@ -4,7 +4,7 @@ package rest_middlewares
 
 import (
 	"errors"
-	"log"
+	"github.com/rs/zerolog/log"
 	"strings"
 
 	"crypto/sha256"
@@ -42,14 +42,18 @@ func AuthMiddleware() gin.HandlerFunc {
 		if key = conf.GetString("http.auth.key"); len(strings.TrimSpace(key)) == 0 {
 			err := c.AbortWithError(500, errors.New("no authentication key provided"))
 			if err != nil {
-				log.Print(err)
+				log.Warn().
+					Err(err).
+					Msg("Missing Authentication Key")
 			}
 			return
 		}
 		if secret = conf.GetString("http.auth.secret"); len(strings.TrimSpace(secret)) == 0 {
 			err := c.AbortWithError(401, errors.New("no authentication secret provided"))
 			if err != nil {
-				log.Print(err)
+				log.Warn().
+					Err(err).
+					Msg("Missing Authentication Secret")
 			}
 			return
 		}
@@ -59,7 +63,9 @@ func AuthMiddleware() gin.HandlerFunc {
 		if !isKeysEqual || !isSecretsEqual {
 			err := c.AbortWithError(401, errors.New("authentication failed"))
 			if err != nil {
-				log.Print(err)
+				log.Warn().
+					Err(err).
+					Msg("Authentication Failed")
 			}
 			return
 		}

--- a/server/rest_server.go
+++ b/server/rest_server.go
@@ -3,7 +3,7 @@ package server
 // adapted from https://github.com/vsouza/go-gin-boilerplate
 import (
 	"github.com/Lachstec/digsinet-ng/config"
-	"log"
+	"github.com/rs/zerolog/log"
 )
 
 func InitRESTServer() {
@@ -11,7 +11,9 @@ func InitRESTServer() {
 	r := NewRESTRouter()
 	err := r.Run(conf.GetString("server.port"))
 	if err != nil {
-		log.Fatal("Unable to start REST server.")
+		log.Fatal().
+			Err(err).
+			Msg("Failed to start REST server")
 		return
 	}
 }


### PR DESCRIPTION
Diese PR implementiert Logging über ZeroLog. Der Logger aus der Standardbibliothek wurde überall durch ZeroLog ausgetauscht. Ein neues Package `log` wurde erstellt, in dem der Logger konfiguriert wird. Hier kann später ggf. auf Structured Logging umgestellt werden.